### PR TITLE
update to pyside and shiboken 5.15.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ kiwisolver==1.1.0
 matplotlib==3.0.3
 numpy==1.16.2
 pyparsing==2.4.0
-PySide2==5.12.2
+PySide2==5.15.1
 python-dateutil==2.8.0
 PyXB==1.2.6
-shiboken2==5.12.2
+shiboken2==5.15.1
 six==1.12.0


### PR DESCRIPTION
Shiboken is broken with python 3.8: https://bugreports.qt.io/browse/PYSIDE-1140
"object is not iterable" error patch.