### PR TITLE
Replacing PySide2 dependency with PyQt5 library

### DIFF
--- a/ismrmrdviewer/__main__.py
+++ b/ismrmrdviewer/__main__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-from PySide2 import QtCore
+from PyQt5 import QtCore
 import ismrmrdviewer.ui as ui
 import sys
 import logging
 import argparse
 
-from PySide2 import QtWidgets
+from PyQt5 import QtWidgets
 
 
 def main():

--- a/ismrmrdviewer/ui/FileWidget.py
+++ b/ismrmrdviewer/ui/FileWidget.py
@@ -1,9 +1,9 @@
 
 import ismrmrd
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
-from PySide2.QtGui import QGuiApplication, QCursor
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QGuiApplication, QCursor
 from ismrmrdviewer.viewer import HeaderViewer, ImageViewer, AcquisitionViewer, WaveformViewer
 
 

--- a/ismrmrdviewer/ui/MainWindow.py
+++ b/ismrmrdviewer/ui/MainWindow.py
@@ -1,16 +1,16 @@
 
 import os
 import logging
-from PySide2 import QtCore
-from PySide2 import QtWidgets
-from PySide2.QtCore import Signal, Slot
+from PyQt5 import QtCore
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import pyqtSignal, pyqtSlot
 
 from .FileWidget import FileWidget
 
 
 class MainWindow(QtWidgets.QMainWindow):
 
-    open = Signal(str)
+    open = pyqtSignal(str)
 
     def __init__(self):
         super().__init__()
@@ -22,7 +22,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.open.connect(self.open_file)
 
-    @Slot()
+    @pyqtSlot()
     def open_file_dialog(self):
 
         file_name, file_type = QtWidgets.QFileDialog.getOpenFileName(

--- a/ismrmrdviewer/viewer/AcquisitionViewer.py
+++ b/ismrmrdviewer/viewer/AcquisitionViewer.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2 import QtWidgets, QtCore, QtGui
-from PySide2.QtCore import Qt
+from PyQt5 import QtWidgets, QtCore, QtGui
+from PyQt5.QtCore import Qt
 
 import numpy as np
 import matplotlib as mpl

--- a/ismrmrdviewer/viewer/HeaderViewer.py
+++ b/ismrmrdviewer/viewer/HeaderViewer.py
@@ -1,7 +1,7 @@
 import logging
 import xml.etree.ElementTree as ET
 
-from PySide2 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore
 
 
 class HeaderViewer(QtWidgets.QTreeWidget):

--- a/ismrmrdviewer/viewer/ImageViewer.py
+++ b/ismrmrdviewer/viewer/ImageViewer.py
@@ -4,7 +4,7 @@ import pdb
 import matplotlib.pyplot as pyplot
 import matplotlib.animation as animation
 
-from PySide2 import QtCore, QtGui, QtWidgets as QTW
+from PyQt5 import QtCore, QtGui, QtWidgets as QTW
 
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure

--- a/ismrmrdviewer/viewer/WaveformViewer.py
+++ b/ismrmrdviewer/viewer/WaveformViewer.py
@@ -1,8 +1,8 @@
 
 import logging
 
-from PySide2 import QtWidgets, QtCore, QtGui
-from PySide2.QtCore import Qt
+from PyQt5 import QtWidgets, QtCore, QtGui
+from PyQt5.QtCore import Qt
 
 import numpy as np
 import matplotlib as mpl

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ kiwisolver==1.1.0
 matplotlib==3.0.3
 numpy==1.16.2
 pyparsing==2.4.0
-PySide2==5.15.1
+PyQt5==5.15.1
 python-dateutil==2.8.0
 shiboken2==5.15.1
 six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'matplotlib',
         'numpy',
         'pyparsing',
-        'PySide2',
+        'PyQt5',
         'python-dateutil',
         'shiboken2',
         'six'


### PR DESCRIPTION
Replacing PySide2 dependency with PyQt5 library
Enabling ismrmrdviewer to work on python 3.9 (solving issue 21)